### PR TITLE
support strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.0
+
+## Additions
+
+- Angu now supports string literals [#3](https://github.com/jsdw/angu/pull/3)
+
 # v0.4.0
 
 ## Breaking Changes

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ that contains the error. Specific errors contain other information depending on 
 
 # Details
 
+## Primitives
+
+Angu supports the following literals:
+
+- booleans ('true' or 'false')
+- numbers
+- strings (strings can be surrounded in ' or ", \'s inside a string escape the delimiter and themselves)
+
+Otherwise, it relies on operators and function calls to transform and manipulate them.
+
 ## Operators
 
 Any of the following characters can be used to define an operator:

--- a/dist/errors.d.ts
+++ b/dist/errors.d.ts
@@ -31,7 +31,11 @@ export declare type InterpretError = {
     input: string;
 };
 /** Parse error */
-export declare type ParseError = ParseErrorMatchString | ParseErrorMustTakeWhile | ParseErrorMustSepBy;
+export declare type ParseError = ParseErrorMatchString | ParseErrorMustTakeWhile | ParseErrorMustSepBy | ParseErrorEndOfString;
+export declare type ParseErrorEndOfString = {
+    kind: 'END_OF_STRING';
+    input: "";
+};
 export declare type ParseErrorMatchString = {
     kind: 'MATCH_STRING';
     expectedOneOf: string[];

--- a/dist/errors.js
+++ b/dist/errors.js
@@ -20,6 +20,7 @@ function addPositionToError(fullInput, error) {
         case 'MUST_TAKE_WHILE':
         case 'MUST_SEP_BY':
         case 'NOT_CONSUMED_ALL':
+        case 'END_OF_STRING':
             start = fullInput.length - error.input.length;
             end = start;
             return __assign({}, error, { pos: { start: start, end: end } });

--- a/dist/expression.d.ts
+++ b/dist/expression.d.ts
@@ -1,5 +1,5 @@
 import { Pos } from "./libparser";
-export declare type Expression = ExprVariable | ExprNumber | ExprBool | ExprFunctioncall;
+export declare type Expression = ExprVariable | ExprNumber | ExprBool | ExprFunctioncall | ExprString;
 export declare type ExprVariable = {
     kind: 'variable';
     name: string;
@@ -21,5 +21,10 @@ export declare type ExprFunctioncall = {
     name: string;
     args: Expression[];
     infix: boolean;
+    pos: Pos;
+};
+export declare type ExprString = {
+    kind: 'string';
+    value: string;
     pos: Pos;
 };

--- a/dist/interpreter.js
+++ b/dist/interpreter.js
@@ -6,6 +6,7 @@ function evaluate(expr, context) {
         case 'number': return evaluateNumber(expr, context);
         case 'bool': return evaluateBool(expr, context);
         case 'functioncall': return evaluateFunctioncall(expr, context);
+        case 'string': return evaluateString(expr, context);
     }
 }
 exports.evaluate = evaluate;
@@ -23,6 +24,9 @@ function evaluateNumber(expr, _context) {
     return new Value(expr, function () { return expr.value; });
 }
 function evaluateBool(expr, _context) {
+    return new Value(expr, function () { return expr.value; });
+}
+function evaluateString(expr, _context) {
     return new Value(expr, function () { return expr.value; });
 }
 function evaluateFunctioncall(expr, context) {

--- a/dist/libparser.d.ts
+++ b/dist/libparser.d.ts
@@ -19,6 +19,8 @@ export default class Parser<T> {
     parse(input: string): ParseResult<T>;
     /** A parser that does nothing */
     static ok<T>(val: T): Parser<T>;
+    /** Any one character. Only fails on an empty string */
+    static anyChar(): Parser<string>;
     /** A convenience function to turn a function scope into a parser to avoid reuse of vars */
     static lazy<T>(fn: () => Parser<T>): Parser<T>;
     /** Return a parser that matches a given string */
@@ -46,6 +48,10 @@ export default class Parser<T> {
     mustSepBy<S>(sep: Parser<S>): Parser<{
         results: T[];
         separators: S[];
+    }>;
+    static takeUntil<T>(untilParser: Parser<T>): Parser<{
+        result: string;
+        until: T;
     }>;
 }
 export {};

--- a/dist/libparser.test.js
+++ b/dist/libparser.test.js
@@ -14,6 +14,12 @@ var libparser_1 = __importDefault(require("./libparser"));
 var result_1 = require("./result");
 var assert = __importStar(require("assert"));
 describe("libparser", function () {
+    it('can match any character', function () {
+        assert.deepEqual(libparser_1.default.anyChar().parse(''), result_1.err({ kind: 'END_OF_STRING', input: '' }));
+        assert.deepEqual(libparser_1.default.anyChar().parse('a'), result_1.ok({ output: 'a', rest: '' }));
+        assert.deepEqual(libparser_1.default.anyChar().parse('*'), result_1.ok({ output: '*', rest: '' }));
+        assert.deepEqual(libparser_1.default.anyChar().parse('abc'), result_1.ok({ output: 'a', rest: 'bc' }));
+    });
     it('can match strings', function () {
         expectDoesMatchString('foo', 'bar', 'foobar');
         expectDoesMatchString('f', 'oobar', 'foobar');
@@ -54,6 +60,11 @@ describe("libparser", function () {
             assert.equal(res.value.output, m);
         }
     }
+    it('can takeUntil', function () {
+        assert.deepEqual(libparser_1.default.takeUntil(libparser_1.default.matchString('l')).parse('foo'), result_1.err({ kind: 'END_OF_STRING', input: '' }));
+        assert.deepEqual(libparser_1.default.takeUntil(libparser_1.default.matchString('l')).parse('fool'), result_1.ok({ output: { result: 'foo', until: 'l' }, rest: '' }));
+        assert.deepEqual(libparser_1.default.takeUntil(libparser_1.default.matchString('l')).parse('list'), result_1.ok({ output: { result: '', until: 'l' }, rest: 'ist' }));
+    });
     it('will get at least one char back from mustTakeWhile', function () {
         var p = libparser_1.default.mustTakeWhile(function (c) { return /[0-9]/.test(c); });
         assert.deepEqual(p.parse('123foo'), result_1.ok({ output: '123', rest: 'foo' }));

--- a/dist/parser.d.ts
+++ b/dist/parser.d.ts
@@ -38,12 +38,14 @@ export declare function anyExpression(opts: InternalExpressionOpts): Parser<Expr
 export declare function binaryOpSubExpression(opts: InternalExpressionOpts): Parser<Expression>;
 export declare function variableExpression(): Parser<Expression>;
 export declare function numberExpression(): Parser<Expression>;
+export declare function stringExpression(): Parser<Expression>;
 export declare function booleanExpression(): Parser<Expression>;
 export declare function unaryOpExpression(opts: InternalExpressionOpts): Parser<Expression>;
 export declare function binaryOpExpression(opts: InternalExpressionOpts): Parser<Expression>;
 export declare function functioncallExpression(opts: InternalExpressionOpts): Parser<Expression>;
 export declare function parenExpression(opts: InternalExpressionOpts): Parser<Expression>;
 export declare function number(): Parser<string>;
+export declare function string(delim: string): Parser<string>;
 export declare function token(): Parser<string>;
 declare type Op = {
     value: string;

--- a/dist/parser.test.js
+++ b/dist/parser.test.js
@@ -24,6 +24,20 @@ describe('parser', function () {
         assert.ok(result_1.isErr(parser.number().eval('9.')));
         assert.ok(result_1.isErr(parser.number().eval('.')));
     });
+    it('parses strings with arbitrary delims properly', function () {
+        assertParsesStrings('"');
+        assertParsesStrings("'");
+    });
+    function assertParsesStrings(delim) {
+        assert.deepEqual(parser.string(delim).eval(delim + "hello" + delim), result_1.ok('hello'));
+        assert.deepEqual(parser.string(delim).eval("" + delim + delim), result_1.ok(''));
+        // '\"" == '"' in the output:
+        assert.deepEqual(parser.string(delim).eval(delim + "hello \\" + delim + " there" + delim), result_1.ok("hello " + delim + " there"));
+        // two '\'s == one escaped '\' in the output:
+        assert.deepEqual(parser.string(delim).eval(delim + "hello \\\\" + delim), result_1.ok('hello \\'));
+        // three '\'s + '"' == one escaped '\' and then an escaped '"':
+        assert.deepEqual(parser.string(delim).eval(delim + "hello \\\\\\" + delim + delim), result_1.ok("hello \\" + delim));
+    }
     it('parses numbers in preference to unary ops', function () {
         // Make sure '-' and '+' are treated as part of the number
         // and not a unary op to apply.
@@ -46,6 +60,10 @@ describe('parser', function () {
     });
     it('parses basic expression types', function () {
         var opts = {};
+        assertRoughlyEqual(parser.expression(opts).eval('""'), result_1.ok({ kind: 'string', value: "" }));
+        assertRoughlyEqual(parser.expression(opts).eval('"hello"'), result_1.ok({ kind: 'string', value: "hello" }));
+        assertRoughlyEqual(parser.expression(opts).eval("'hello'"), result_1.ok({ kind: 'string', value: "hello" }));
+        assertRoughlyEqual(parser.expression(opts).eval('("hello")'), result_1.ok({ kind: 'string', value: "hello" }));
         assertRoughlyEqual(parser.expression(opts).eval('true'), result_1.ok({ kind: 'bool', value: true }));
         assertRoughlyEqual(parser.expression(opts).eval('false'), result_1.ok({ kind: 'bool', value: false }));
         assertRoughlyEqual(parser.expression(opts).eval('foo'), result_1.ok({ kind: 'variable', name: 'foo' }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angu",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angu",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A small interpreter for creating DSLs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -57,7 +57,12 @@ export type ParseError
     = ParseErrorMatchString
     | ParseErrorMustTakeWhile
     | ParseErrorMustSepBy
+    | ParseErrorEndOfString
 
+export type ParseErrorEndOfString = {
+    kind: 'END_OF_STRING',
+    input: ""
+}
 export type ParseErrorMatchString = {
     kind: 'MATCH_STRING'
     expectedOneOf: string[]
@@ -81,6 +86,7 @@ export function addPositionToError(fullInput: string, error: ErrorWithoutPositio
         case 'MUST_TAKE_WHILE':
         case 'MUST_SEP_BY':
         case 'NOT_CONSUMED_ALL':
+        case 'END_OF_STRING':
             start = fullInput.length - error.input.length
             end = start
             return { ...error, pos: { start, end } }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -5,8 +5,10 @@ export type Expression
     | ExprNumber
     | ExprBool
     | ExprFunctioncall
+    | ExprString
 
 export type ExprVariable = { kind: 'variable', name: string, pos: Pos }
 export type ExprNumber = { kind: 'number', value: number, string: string, pos: Pos }
 export type ExprBool = { kind: 'bool', value: boolean, pos: Pos }
 export type ExprFunctioncall = { kind: 'functioncall', name: string, args: Expression[], infix: boolean, pos: Pos}
+export type ExprString = { kind: 'string', value: string, pos: Pos }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,4 +1,4 @@
-import { Expression, ExprVariable, ExprNumber, ExprBool, ExprFunctioncall } from './expression'
+import { Expression, ExprVariable, ExprNumber, ExprBool, ExprFunctioncall, ExprString } from './expression'
 import { EvalError } from './errors'
 import { ExpressionOpts } from './parser'
 
@@ -27,6 +27,7 @@ export function evaluate(expr: Expression, context: Context): Value {
         case 'number': return evaluateNumber(expr, context)
         case 'bool': return evaluateBool(expr, context)
         case 'functioncall': return evaluateFunctioncall(expr, context)
+        case 'string': return evaluateString(expr, context)
     }
 }
 
@@ -46,6 +47,10 @@ function evaluateNumber(expr: ExprNumber, _context: Context): Value<number> {
 }
 
 function evaluateBool(expr: ExprBool, _context: Context): Value<boolean> {
+    return new Value(expr, () => expr.value)
+}
+
+function evaluateString(expr: ExprString, _context: Context): Value {
     return new Value(expr, () => expr.value)
 }
 

--- a/src/libparser.test.ts
+++ b/src/libparser.test.ts
@@ -1,8 +1,15 @@
 import Parser from './libparser'
-import { isOk, isErr, ok } from './result'
+import { isOk, isErr, ok, err } from './result'
 import * as assert from 'assert'
 
 describe("libparser", function() {
+
+    it('can match any character', () => {
+        assert.deepEqual(Parser.anyChar().parse(''), err({ kind: 'END_OF_STRING', input: '' }))
+        assert.deepEqual(Parser.anyChar().parse('a'), ok({ output: 'a', rest: '' }))
+        assert.deepEqual(Parser.anyChar().parse('*'), ok({ output: '*', rest: '' }))
+        assert.deepEqual(Parser.anyChar().parse('abc'), ok({ output: 'a', rest: 'bc' }))
+    })
 
     it('can match strings', () => {
         expectDoesMatchString('foo', 'bar', 'foobar')
@@ -48,6 +55,12 @@ describe("libparser", function() {
             assert.equal(res.value.output, m)
         }
     }
+
+    it('can takeUntil', () => {
+        assert.deepEqual(Parser.takeUntil(Parser.matchString('l')).parse('foo'), err({ kind: 'END_OF_STRING', input: '' }))
+        assert.deepEqual(Parser.takeUntil(Parser.matchString('l')).parse('fool'), ok({ output: { result: 'foo', until: 'l' }, rest: '' }))
+        assert.deepEqual(Parser.takeUntil(Parser.matchString('l')).parse('list'), ok({ output: { result: '', until: 'l' }, rest: 'ist' }))
+    })
 
     it('will get at least one char back from mustTakeWhile', () => {
         const p = Parser.mustTakeWhile(c => /[0-9]/.test(c))


### PR DESCRIPTION
Add support for strings, using ' or " as the delimiters. Support escaping delimiters inside a string using \, (eg \" or \'), and escaping backslashes to render them (eg \\ to render \).